### PR TITLE
Enable container to use host's network interface

### DIFF
--- a/agent/api/task.go
+++ b/agent/api/task.go
@@ -314,6 +314,7 @@ func (task *Task) dockerHostConfig(container *Container, dockerContainerMap map[
 		Binds:        binds,
 		PortBindings: dockerPortMap,
 		VolumesFrom:  volumesFrom,
+		NetworkMode:  "host",
 	}
 
 	if container.DockerConfig.HostConfig != nil {

--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -294,6 +294,7 @@ func (dg *DockerGoClient) createScratchImageIfNotExists() error {
 
 func (dg *DockerGoClient) CreateContainer(config *docker.Config, hostConfig *docker.HostConfig, name string) DockerContainerMetadata {
 	timeout := ttime.After(createContainerTimeout)
+	hostConfig.NetworkMode = "host"
 
 	ctx, cancelFunc := context.WithCancel(context.TODO()) // Could pass one through from engine
 	response := make(chan DockerContainerMetadata, 1)
@@ -309,6 +310,8 @@ func (dg *DockerGoClient) CreateContainer(config *docker.Config, hostConfig *doc
 
 func (dg *DockerGoClient) createContainer(ctx context.Context, config *docker.Config, hostConfig *docker.HostConfig, name string) DockerContainerMetadata {
 	client, err := dg.dockerClient()
+	hostConfig.NetworkMode = "host"
+
 	if err != nil {
 		return DockerContainerMetadata{Error: CannotGetDockerClientError{version: dg.version, err: err}}
 	}

--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -443,6 +443,8 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 	}
 
 	hostConfig, hcerr := task.DockerHostConfig(container, containerMap)
+	hostConfig.NetworkMode = "host"
+
 	if hcerr != nil {
 		return DockerContainerMetadata{Error: api.NamedError(hcerr)}
 	}
@@ -474,6 +476,8 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
 		return metadata
 	}
 	engine.state.AddContainer(&api.DockerContainer{DockerId: metadata.DockerId, DockerName: containerName, Container: container}, task)
+	hostConfig.NetworkMode = "host"
+
 	log.Info("Created container successfully", "task", task, "container", container)
 	return metadata
 }


### PR DESCRIPTION
@achille-roussel @ber-velvel 
Finally I have got this to work after trying everything out, literally!

I forked the latest amazon-ecs-agent official repo and made the changes to it so that it sets the NetworkMode of any new container it launches to be `host`. This allows the container to use the host's network interface. I tested by deploying the consul agent on `prometheus` cluster using an ECS task, https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/prometheus/tasks, and it is showing up at https://consul.franklychat.com/ui/#/us-east/nodes/ip-10-0-22-17.

Here's a screenshot showing the network interface of the consul container - 
<img width="1282" alt="screen shot 2015-10-23 at 1 46 36 am" src="https://cloud.githubusercontent.com/assets/4392764/10688262/fa925590-7927-11e5-9e18-1be33be2ccd3.png">

The next step is to change our agent playbook to use this modified ecs-agent, so we can start leveraging ECS tasks and services to start spinning up our service containers.

Please let me know if something should be changed.

Exciting times!
